### PR TITLE
Proxied remote gems should never be added as local gems

### DIFF
--- a/lib/geminabox/proxy/hostess.rb
+++ b/lib/geminabox/proxy/hostess.rb
@@ -48,24 +48,11 @@ module Geminabox
       end
 
       get "/gems/*.gem" do
-        get_from_rubygems_if_not_local
+        copy_file request.path_info[1..-1]
         serve
       end
 
       private
-      def get_from_rubygems_if_not_local
-
-        file = File.expand_path(File.join(Geminabox.data, *request.path_info))
-
-        unless File.exist?(file)
-          ruby_gems_url = Geminabox.ruby_gems_url
-          path = File.join(ruby_gems_url, *request.path_info)
-          content = Geminabox.http_adapter.get_content(path)
-          GemStore.create(IncomingGem.new(StringIO.new(content)))
-        end
-
-      end
-
       def splice_file(file_name)
         self.file_handler = Splicer.make(file_name)
       end


### PR DESCRIPTION
> NOTE: I cherry picked this branch out of jeremy/geminabox, and rebased it off master.

Since local gems take precedence over remote gems, if proxying a remote gem
adds it as a local gem, then that one proxied gem now takes precedence over
all other versions of the remote gem. Surprising behavior!

To fix, proxy just the .gem file. Don't add to the local gem store.

This should also result in a significant performance boost, since installing
a proxied remote gem will no longer add a local gem and kick off a very
expensive reindex.

Note: There is no test coverage for this part of the server.